### PR TITLE
Portforward mapping revised

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Pieter Lange <pieter@ptlc.nl>
 
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
     echo "http://dl-4.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn iptables bash easy-rsa libintl && \
+    apk add --update openvpn iptables bash easy-rsa libintl inotify-tools && \
     apk add --virtual build_deps gettext &&  \
     cp /usr/bin/envsubst /usr/local/bin/envsubst && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
@@ -15,18 +15,22 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/reposi
 # Needed by scripts
 ENV OPENVPN /etc/openvpn
 ENV OVPN_TEMPLATE $OPENVPN/templates/openvpn.tmpl
-ENV OVPN_PORTMAPPING $OPENVPN/iptables
 ENV OVPN_CONFIG $OPENVPN/openvpn.conf
+
+ENV OVPN_PORTMAPPING $OPENVPN/portmapping
+ENV OVPN_CCD $OPENVPN/ccd
+ENV OVPN_DEFROUTE 0
+
 ENV EASYRSA /usr/share/easy-rsa
 ENV EASYRSA_PKI $OPENVPN/pki
-ENV OVPN_DEFROUTE 0
 
 # Some PKI scripts.
 ADD ./bin /usr/local/bin
 RUN chmod a+x /usr/local/bin/*
 
-# entry point takes care of setting conf values
+# Initialisation scripts and default template
 COPY entrypoint.sh /sbin/entrypoint.sh
+COPY watch-portmapping.sh /sbin/watch-portmapping.sh
 COPY openvpn.tmpl $OVPN_TEMPLATE
 
 CMD ["/sbin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/reposi
 # Needed by scripts
 ENV OPENVPN /etc/openvpn
 ENV OVPN_TEMPLATE $OPENVPN/templates/openvpn.tmpl
-ENV OVPN_PORTMAPPING $OPENVPN/iptables/portmapping
+ENV OVPN_PORTMAPPING $OPENVPN/iptables
 ENV OVPN_CONFIG $OPENVPN/openvpn.conf
 ENV EASYRSA /usr/share/easy-rsa
 ENV EASYRSA_PKI $OPENVPN/pki

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community/" >> /etc/apk/reposi
 # Needed by scripts
 ENV OPENVPN /etc/openvpn
 ENV OVPN_TEMPLATE $OPENVPN/templates/openvpn.tmpl
+ENV OVPN_PORTMAPPING $OPENVPN/iptables/portmapping
 ENV OVPN_CONFIG $OPENVPN/openvpn.conf
 ENV EASYRSA /usr/share/easy-rsa
 ENV EASYRSA_PKI $OPENVPN/pki

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 if [ "$DEBUG" == "1" ]; then
     set -x
 fi
@@ -58,11 +57,12 @@ iptables -t nat -A POSTROUTING -s ${OVPN_NETWORK} -o ${OVPN_NATDEVICE} -j MASQUE
 if [ -d "$OPENVPN/ccd" ]; then
     addArg "--client-config-dir" "$OPENVPN/ccd"
 
-    if [ -f $OVPN_PORTMAPPING ]; then
-      while IFS='=' read port destination; do
-        echo "Routing ${PODIPADDR}:${port} to ${destination}"
-        iptables -t nat -A PREROUTING -p tcp -d $PODIPADDR --dport ${port} -j DNAT --to $destination
-      done < $OVPN_PORTMAPPING
+    if [ -d ${OVPN_PORTMAPPING} ]; then
+        for port in $(ls -1 ${OVPN_PORTMAPPING}); do
+            destination=$(cat ${OVPN_PORTMAPPING}/${port})
+            echo "Routing ${PODIPADDR}:${port} to ${destination}"
+            iptables -t nat -A PREROUTING -p tcp -d $PODIPADDR --dport ${port} -j DNAT --to $destination
+        done
     fi
 fi
 

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -72,6 +72,17 @@ data:
 ---
 EOCONFIGMAP
 
+kubectl create --namespace=$namespace -f - <<- EOCONFIGMAP
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openvpn-iptables
+data:
+  portmapping: "28080=10.140.0.20:80"
+---
+EOCONFIGMAP
+
+
 kubectl create --namespace=$namespace -f - <<- EODEPLOYMENT
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -108,6 +119,8 @@ spec:
           name: openvpn-crl
         - mountPath: /etc/openvpn/ccd
           name: openvpn-ccd
+        - mountPath: /etc/openvpn/iptables
+          name: openvpn-iptables
         env:
         - name: PODIPADDR
           valueFrom:
@@ -143,6 +156,9 @@ spec:
       - name: openvpn-crl
         configMap:
           name: openvpn-crl
+      - name: openvpn-iptables
+        configMap:
+          name: openvpn-iptables
 ---
 EODEPLOYMENT
 

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -76,9 +76,9 @@ kubectl create --namespace=$namespace -f - <<- EOCONFIGMAP
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: openvpn-iptables
+  name: openvpn-portmapping
 data:
-  20080: "10.140.0.20:80"
+  20080: "example:80"
 ---
 EOCONFIGMAP
 
@@ -119,8 +119,8 @@ spec:
           name: openvpn-crl
         - mountPath: /etc/openvpn/ccd
           name: openvpn-ccd
-        - mountPath: /etc/openvpn/iptables
-          name: openvpn-iptables
+        - mountPath: /etc/openvpn/portmapping
+          name: openvpn-portmapping
         env:
         - name: PODIPADDR
           valueFrom:
@@ -156,9 +156,9 @@ spec:
       - name: openvpn-crl
         configMap:
           name: openvpn-crl
-      - name: openvpn-iptables
+      - name: openvpn-portmapping
         configMap:
-          name: openvpn-iptables
+          name: openvpn-portmapping
 ---
 EODEPLOYMENT
 

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -78,7 +78,7 @@ kind: ConfigMap
 metadata:
   name: openvpn-iptables
 data:
-  portmapping: "28080=10.140.0.20:80"
+  20080: "10.140.0.20:80"
 ---
 EOCONFIGMAP
 

--- a/watch-portmapping.sh
+++ b/watch-portmapping.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+[ $DEBUG ] && set -x
+
+while true; do
+    if [ -d $OVPN_CCD ]; then
+
+        if [ -d $OVPN_PORTMAPPING ]; then
+            inotifywait -e modify -e create -e delete $OVPN_PORTMAPPING
+
+            # Flush any old rules.
+            iptables -t nat -F
+            for port in $(ls -1 ${OVPN_PORTMAPPING}); do
+                dest_cname=$(cut -d':' -f1 ${OVPN_PORTMAPPING}/${port})
+                dest_port=$(cut -d':' -f2 ${OVPN_PORTMAPPING}/${port})
+                if [ -f ${OVPN_CCD}/${dest_cname} ]; then
+                    dest_ip=$(grep 'ifconfig-push' $OVPN_CCD/${dest_cname} | cut -d' ' -f2)
+                    echo "Routing ${PODIPADDR}:${port} to ${dest_ip}:${dest_port} (${dest_cname})"
+                    iptables -t nat -A PREROUTING -p tcp -d $PODIPADDR --dport ${port} -j DNAT --to ${dest_ip}:${dest_port}
+                else
+                    echo "ERROR: client configuration for ${dest_cname} not found"
+                fi
+            done
+        else
+            # Watch $OPENVPN directory for portmapping directory creation
+            inotifywait -e create -qq $OPENVPN
+
+            # Give it time to settle
+            sleep 60
+        fi
+    else
+        # Watch $OPENVPN directory for client configuration directory creation
+        inotifywait -e create -qq $OPENVPN
+
+        # Give it time to settle
+        sleep 60
+    fi
+done

--- a/watch-portmapping.sh
+++ b/watch-portmapping.sh
@@ -5,8 +5,6 @@ while true; do
     if [ -d $OVPN_CCD ]; then
 
         if [ -d $OVPN_PORTMAPPING ]; then
-            inotifywait -e modify -e create -e delete $OVPN_PORTMAPPING
-
             # Flush any old rules.
             iptables -t nat -F
             for port in $(ls -1 ${OVPN_PORTMAPPING}); do
@@ -20,6 +18,9 @@ while true; do
                     echo "ERROR: client configuration for ${dest_cname} not found"
                 fi
             done
+
+            # Done. Block for updates to configmap.
+            inotifywait -e modify -e create -e delete $OVPN_PORTMAPPING
         else
             # Watch $OPENVPN directory for portmapping directory creation
             inotifywait -e create -qq $OPENVPN

--- a/watch-portmapping.sh
+++ b/watch-portmapping.sh
@@ -2,6 +2,8 @@
 [ $DEBUG ] && set -x
 
 iptables -t nat -N KUBEOPENVPNPORTFORWARD
+iptables -t nat -A KUBEOPENVPNPORTFORWARD -j ACCEPT
+
 iptables -t nat -A PREROUTING -j KUBEOPENVPNPORTFORWARD
 
 while true; do

--- a/watch-portmapping.sh
+++ b/watch-portmapping.sh
@@ -5,7 +5,7 @@ while true; do
     if [ -d $OVPN_CCD ]; then
 
         if [ -d $OVPN_PORTMAPPING ]; then
-            # Flush any old rules.
+            # Flush any old NAT rules.
             iptables -t nat -F
             for port in $(ls -1 ${OVPN_PORTMAPPING}); do
                 dest_cname=$(cut -d':' -f1 ${OVPN_PORTMAPPING}/${port})
@@ -20,17 +20,17 @@ while true; do
             done
 
             # Done. Block for updates to configmap.
-            inotifywait -e modify -e create -e delete $OVPN_PORTMAPPING
+            inotifywait -qq -e modify -e create -e delete $OVPN_PORTMAPPING
         else
             # Watch $OPENVPN directory for portmapping directory creation
-            inotifywait -e create -qq $OPENVPN
+            inotifywait -qq -e create $OPENVPN
 
             # Give it time to settle
             sleep 60
         fi
     else
         # Watch $OPENVPN directory for client configuration directory creation
-        inotifywait -e create -qq $OPENVPN
+        inotifywait -qq -e create $OPENVPN
 
         # Give it time to settle
         sleep 60

--- a/watch-portmapping.sh
+++ b/watch-portmapping.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
 [ $DEBUG ] && set -x
 
+iptables -t nat -N KUBEOPENVPNPORTFORWARD
+iptables -t nat -A PREROUTING -j KUBEOPENVPNPORTFORWARD
+
 while true; do
     if [ -d $OVPN_CCD ]; then
 
         if [ -d $OVPN_PORTMAPPING ]; then
             # Flush any old NAT rules.
-            iptables -t nat -F
+            iptables -t nat -F KUBEOPENVPNPORTFORWARD
+
             for port in $(ls -1 ${OVPN_PORTMAPPING}); do
                 dest_cname=$(cut -d':' -f1 ${OVPN_PORTMAPPING}/${port})
                 dest_port=$(cut -d':' -f2 ${OVPN_PORTMAPPING}/${port})
                 if [ -f ${OVPN_CCD}/${dest_cname} ]; then
                     dest_ip=$(grep 'ifconfig-push' $OVPN_CCD/${dest_cname} | cut -d' ' -f2)
                     echo "Routing ${PODIPADDR}:${port} to ${dest_ip}:${dest_port} (${dest_cname})"
-                    iptables -t nat -A PREROUTING -p tcp -d $PODIPADDR --dport ${port} -j DNAT --to ${dest_ip}:${dest_port}
+                    iptables -t nat -A KUBEOPENVPNPORTFORWARD -p tcp -d $PODIPADDR --dport ${port} -j DNAT --to ${dest_ip}:${dest_port}
                 else
                     echo "ERROR: client configuration for ${dest_cname} not found"
                 fi


### PR DESCRIPTION
Reimplemented the 'route back to clients' feature to use a `ConfigMap` (fixes #14). I hope this makes the feature more straightforward to use.

Features:
  * Run a `inotifywait` loop script to update iptables rules on updates to the configmap. This means you no longer have to restart the VPN pod to update portmaps. :tada:
  * Port forwards are configured in a specific iptables chain (`KUBEOPENVPNPORTFORWARD`)

In order to use this feature, create or edit the 'openvpn-portmapping' ConfigMap. Use the keys to define the port on the kube-openvpn pod and specify the target client `CommonName:serviceport` as value. The client will need to have a static IP configured in the `openvpn-ccd` ConfigMap.

Example configmap:
```yaml
apiVersion: v1
metadata:
  name: openvpn-portmapping
kind: ConfigMap
data:
  "20080": example:80
  "20081": hisapp:8080
```