### PR TITLE
Improved check for base64 options

### DIFF
--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -26,7 +26,9 @@ if [ ! -d pki ]; then
     exit 1
 fi
 
-if [ $(uname -s) == "Linux" ]; then
+# test if -w0 is a valid option
+base64 -w0 /dev/null > /dev/null 2>&1
+if [ $? -eq 0 ]; then
     base64="base64 -w0"
 else
     base64="base64"


### PR DESCRIPTION
Previous version checked if the script was being run in Linux.  This
tests the actual command to see if `-w0` is accepted since some may use GNU's base64 on non-Linux platforms (e.g., MacOS)