### PR TITLE
Update alpine & openvpn, fix PKI permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Smallest base image
-FROM alpine:3.6
+FROM alpine:3.7
 
 MAINTAINER Pieter Lange <pieter@ptlc.nl>
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update openvpn=2.4.3-r0 \
+    apk add --update openvpn=2.4.4-r1 \
       bash easy-rsa libintl inotify-tools openvpn-auth-pam google-authenticator pamtester && \
     apk add --virtual temppkg gettext &&  \
     cp /usr/bin/envsubst /usr/local/bin/envsubst && \

--- a/kube/deployment.yaml
+++ b/kube/deployment.yaml
@@ -59,6 +59,7 @@ spec:
       - name: openvpn-pki
         secret:
           secretName: openvpn-pki
+          defaultMode: 0400
       - name: openvpn-ccd
         configMap:
           name: openvpn-ccd


### PR DESCRIPTION
These changes update the version of alpine and openvpn to the latest releases and also properly set the permissions of the PKI volume mount so it is readable only by root.

I've tested both changes in a newly created environment.

Thanks for the work on this!